### PR TITLE
feat: [OBSOLETE, PLEASE DELETE] create file extension helper function and reorder zip functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docubleach"
-version = "0.1.0"
+version = "0.1.2"
 description = "Tool to purge and remove all macro and dynamic content from an MS Office file"
 authors = ["Patterbear"]
 license = "MIT"


### PR DESCRIPTION
I wrote a helper function to get file extensions rather than repeating the same code in several functions.

I also moved the rezip function to underneath the unzip one as it seems more logical.

The reason the version goes from 0.1.0 to 0.1.2 is because 0.1.1 is the currently released version on PyPi with the updated README - I forgot to update the version number when I pushed the new readme.